### PR TITLE
modal esc event stopPropagation

### DIFF
--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -250,7 +250,7 @@
                         this.close();
                     }
                 }
-                e.stopPropagation();
+                e.stopPropagation();//add stopPropagation
             },
             animationFinish() {
                 this.$emit('on-hidden');


### PR DESCRIPTION
### Modal‘s EscClose Function need stopPropagation
Modal in 3.0, it supports prop of draggable & mask.
When we add lots of  modal at the same time. I press ESC to close the top of modal,but it closes all of modal,so i think the Modal widget should add `e.stopPropagation` in EscClose Func to resolve more than one modals at the same time.
### Modal EscClose 方法添加阻止冒泡事件
在iview3.0中Modal支持了draggable和mask，这使得多Modal同时存在的场景增多，当我有多个Modal时按下esc，通常用户习惯是只想关闭置顶的那个，但如果不阻止冒泡就会全部关闭。
```javascript
e.stopPropagation();
```
